### PR TITLE
Refactor director dashboard into reusable components

### DIFF
--- a/src/app/director-dashboard/page.tsx
+++ b/src/app/director-dashboard/page.tsx
@@ -1,11 +1,8 @@
 'use client';
 
 import {
-  ArrowRightOnRectangleIcon,
   ChartBarIcon,
-  ClockIcon,
   DocumentArrowDownIcon,
-  ExclamationTriangleIcon,
   EyeIcon,
   FilmIcon,
   QuestionMarkCircleIcon,
@@ -15,6 +12,14 @@ import React, { useEffect, useState } from 'react';
 import { authAPI } from '@/lib/api';
 
 import ProtectedRoute from '@/components/ProtectedRoute';
+import DashboardHeader from '@/components/ui/DashboardHeader';
+import QuickActions, { QuickAction } from '@/components/QuickActions';
+import StatCard from '@/components/StatCard';
+import LiveSessionStatus from '@/components/director/LiveSessionStatus';
+import ShowCard from '@/components/director/ShowCard';
+import CapabilitiesByRole from '@/app/components/users/CapabilitiesByRole';
+import LimitationsByRole from '@/app/components/users/LimitationsByRole';
+import { Spinner } from '@/components/ui/Spinner';
 
 import { useAuth } from '@/contexts/AuthContext';
 
@@ -26,11 +31,31 @@ interface DirectorDashboardData {
 }
 
 export default function DirectorDashboard() {
-  const { user, logout } = useAuth();
+  const { user } = useAuth();
   const [dashboardData, setDashboardData] =
     useState<DirectorDashboardData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const actions: QuickAction[] = [
+    {
+      icon: <QuestionMarkCircleIcon className='h-5 w-5' />,
+      title: 'Crear Pregunta',
+      description: 'Diseñar nueva pregunta interactiva',
+      color: 'blue',
+    },
+    {
+      icon: <EyeIcon className='h-5 w-5' />,
+      title: 'Iniciar Función',
+      description: 'Comenzar sesión en vivo',
+      color: 'green',
+    },
+    {
+      icon: <ChartBarIcon className='h-5 w-5' />,
+      title: 'Ver Resultados',
+      description: 'Analizar respuestas en tiempo real',
+      color: 'purple',
+    },
+  ];
 
   useEffect(() => {
     const fetchDashboardData = async () => {
@@ -50,49 +75,14 @@ export default function DirectorDashboard() {
   }, []);
 
   if (isLoading) {
-    return (
-      <div className='flex justify-center items-center min-h-screen bg-blue-50'>
-        <div className='animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600'></div>
-        <span className='ml-3 text-gray-600'>Cargando dashboard...</span>
-      </div>
-    );
+    return <Spinner color='blue' />;
   }
 
   return (
     <ProtectedRoute allowedRoles={['director']}>
       <div className='min-h-screen bg-blue-50'>
         {/* Header */}
-        <header className='bg-white shadow-sm border-b-4 border-blue-500'>
-          <div className='max-w-7xl mx-auto px-4 sm:px-6 lg:px-8'>
-            <div className='flex justify-between items-center py-4'>
-              <div className='flex items-center'>
-                <div className='text-3xl mr-3'>🎬</div>
-                <div>
-                  <h1 className='text-2xl font-bold text-blue-800'>
-                    Dashboard Director
-                  </h1>
-                  <p className='text-blue-600'>Bienvenido, {user?.name}</p>
-                </div>
-              </div>
-
-              <div className='flex items-center space-x-4'>
-                <button
-                  onClick={() => (window.location.href = '/')}
-                  className='text-gray-600 hover:text-gray-800 px-3 py-2 rounded-md text-sm'
-                >
-                  Inicio
-                </button>
-                <button
-                  onClick={logout}
-                  className='bg-red-600 text-white px-4 py-2 rounded-md text-sm hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 flex items-center'
-                >
-                  <ArrowRightOnRectangleIcon className='h-4 w-4 mr-2' />
-                  Cerrar Sesión
-                </button>
-              </div>
-            </div>
-          </div>
-        </header>
+        <DashboardHeader icon='🎬' title='Dashboard Director' color='blue' />
 
         <div className='max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8'>
           {error ? (
@@ -113,170 +103,48 @@ export default function DirectorDashboard() {
 
               {/* Quick Stats */}
               <div className='grid grid-cols-1 md:grid-cols-4 gap-6 mb-8'>
-                <div className='bg-white rounded-lg shadow-sm p-6 border-t-4 border-blue-500'>
-                  <div className='flex items-center'>
-                    <div className='flex-shrink-0'>
-                      <FilmIcon className='h-8 w-8 text-blue-600' />
-                    </div>
-                    <div className='ml-4'>
-                      <p className='text-sm font-medium text-gray-500'>
-                        Obras Asignadas
-                      </p>
-                      <p className='text-2xl font-bold text-gray-900'>5</p>
-                    </div>
-                  </div>
-                </div>
-
-                <div className='bg-white rounded-lg shadow-sm p-6 border-t-4 border-green-500'>
-                  <div className='flex items-center'>
-                    <div className='flex-shrink-0'>
-                      <QuestionMarkCircleIcon className='h-8 w-8 text-green-600' />
-                    </div>
-                    <div className='ml-4'>
-                      <p className='text-sm font-medium text-gray-500'>
-                        Preguntas Creadas
-                      </p>
-                      <p className='text-2xl font-bold text-gray-900'>42</p>
-                    </div>
-                  </div>
-                </div>
-
-                <div className='bg-white rounded-lg shadow-sm p-6 border-t-4 border-purple-500'>
-                  <div className='flex items-center'>
-                    <div className='flex-shrink-0'>
-                      <EyeIcon className='h-8 w-8 text-purple-600' />
-                    </div>
-                    <div className='ml-4'>
-                      <p className='text-sm font-medium text-gray-500'>
-                        Funciones Dirigidas
-                      </p>
-                      <p className='text-2xl font-bold text-gray-900'>18</p>
-                    </div>
-                  </div>
-                </div>
-
-                <div className='bg-white rounded-lg shadow-sm p-6 border-t-4 border-orange-500'>
-                  <div className='flex items-center'>
-                    <div className='flex-shrink-0'>
-                      <DocumentArrowDownIcon className='h-8 w-8 text-orange-600' />
-                    </div>
-                    <div className='ml-4'>
-                      <p className='text-sm font-medium text-gray-500'>
-                        Reportes PDF
-                      </p>
-                      <p className='text-2xl font-bold text-gray-900'>12</p>
-                    </div>
-                  </div>
-                </div>
+                <StatCard
+                  icon={<FilmIcon className='h-5 w-5' />}
+                  title='Obras Asignadas'
+                  value={5}
+                  color='blue'
+                />
+                <StatCard
+                  icon={<QuestionMarkCircleIcon className='h-5 w-5' />}
+                  title='Preguntas Creadas'
+                  value={42}
+                  color='green'
+                />
+                <StatCard
+                  icon={<EyeIcon className='h-5 w-5' />}
+                  title='Funciones Dirigidas'
+                  value={18}
+                  color='purple'
+                />
+                <StatCard
+                  icon={<DocumentArrowDownIcon className='h-5 w-5' />}
+                  title='Reportes PDF'
+                  value={12}
+                  color='orange'
+                />
               </div>
 
               {/* Main Content Grid */}
               <div className='grid grid-cols-1 lg:grid-cols-2 gap-8'>
-                {/* Capabilities */}
-                <div className='bg-white rounded-lg shadow-sm p-6'>
-                  <h3 className='text-lg font-semibold text-gray-900 mb-4 flex items-center'>
-                    <span className='text-xl mr-2'>🎯</span>
-                    Capacidades del Director
-                  </h3>
-                  <div className='space-y-3'>
-                    {dashboardData.capabilities.map((capability, index) => (
-                      <div key={index} className='flex items-start'>
-                        <div className='flex-shrink-0 mt-1'>
-                          <div className='w-2 h-2 bg-blue-500 rounded-full'></div>
-                        </div>
-                        <p className='ml-3 text-gray-700'>{capability}</p>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-
-                {/* Limitations */}
-                <div className='bg-yellow-50 rounded-lg border border-yellow-200 p-6'>
-                  <h3 className='text-lg font-semibold text-gray-900 mb-4 flex items-center'>
-                    <ExclamationTriangleIcon className='h-5 w-5 text-yellow-600 mr-2' />
-                    Limitaciones
-                  </h3>
-                  <div className='space-y-3'>
-                    {dashboardData.limitations.map((limitation, index) => (
-                      <div key={index} className='flex items-start'>
-                        <div className='flex-shrink-0 mt-1'>
-                          <div className='w-2 h-2 bg-yellow-500 rounded-full'></div>
-                        </div>
-                        <p className='ml-3 text-yellow-800'>{limitation}</p>
-                      </div>
-                    ))}
-                  </div>
-                </div>
+                <CapabilitiesByRole capabilities={dashboardData.capabilities} />
+                <LimitationsByRole limitations={dashboardData.limitations} />
               </div>
 
               {/* Live Session Status */}
-              <div className='mt-8 bg-gradient-to-r from-blue-500 to-purple-600 rounded-lg p-6 text-white'>
-                <h3 className='text-lg font-semibold mb-4 flex items-center'>
-                  <ClockIcon className='h-5 w-5 mr-2' />
-                  Estado de Sesión en Vivo
-                </h3>
-                <div className='grid grid-cols-1 md:grid-cols-3 gap-4'>
-                  <div className='bg-white bg-opacity-20 rounded-lg p-4'>
-                    <p className='text-sm opacity-90'>Próxima Función</p>
-                    <p className='font-semibold text-lg'>
-                      "Romeo y Julieta 2.0"
-                    </p>
-                    <p className='text-sm opacity-75'>Hoy, 20:00</p>
-                  </div>
-                  <div className='bg-white bg-opacity-20 rounded-lg p-4'>
-                    <p className='text-sm opacity-90'>Espectadores Esperados</p>
-                    <p className='font-semibold text-2xl'>156</p>
-                  </div>
-                  <div className='bg-white bg-opacity-20 rounded-lg p-4'>
-                    <p className='text-sm opacity-90'>Preguntas Preparadas</p>
-                    <p className='font-semibold text-2xl'>8</p>
-                  </div>
-                </div>
-              </div>
+              <LiveSessionStatus
+                play='"Romeo y Julieta 2.0"'
+                showTime='Hoy, 20:00'
+                expectedViewers={156}
+                questionCount={8}
+              />
 
               {/* Quick Actions */}
-              <div className='mt-8 bg-white rounded-lg shadow-sm p-6'>
-                <h3 className='text-lg font-semibold text-gray-900 mb-4'>
-                  Acciones Rápidas
-                </h3>
-                <div className='grid grid-cols-1 md:grid-cols-3 gap-4'>
-                  <button className='p-4 border-2 border-blue-200 rounded-lg hover:bg-blue-50 transition-colors text-left group'>
-                    <div className='flex items-center mb-2'>
-                      <QuestionMarkCircleIcon className='h-5 w-5 text-blue-600 mr-2 group-hover:scale-110 transition-transform' />
-                      <span className='font-medium text-blue-800'>
-                        Crear Pregunta
-                      </span>
-                    </div>
-                    <p className='text-sm text-gray-600'>
-                      Diseñar nueva pregunta interactiva
-                    </p>
-                  </button>
-
-                  <button className='p-4 border-2 border-green-200 rounded-lg hover:bg-green-50 transition-colors text-left group'>
-                    <div className='flex items-center mb-2'>
-                      <EyeIcon className='h-5 w-5 text-green-600 mr-2 group-hover:scale-110 transition-transform' />
-                      <span className='font-medium text-green-800'>
-                        Iniciar Función
-                      </span>
-                    </div>
-                    <p className='text-sm text-gray-600'>
-                      Comenzar sesión en vivo
-                    </p>
-                  </button>
-
-                  <button className='p-4 border-2 border-purple-200 rounded-lg hover:bg-purple-50 transition-colors text-left group'>
-                    <div className='flex items-center mb-2'>
-                      <ChartBarIcon className='h-5 w-5 text-purple-600 mr-2 group-hover:scale-110 transition-transform' />
-                      <span className='font-medium text-purple-800'>
-                        Ver Resultados
-                      </span>
-                    </div>
-                    <p className='text-sm text-gray-600'>
-                      Analizar respuestas en tiempo real
-                    </p>
-                  </button>
-                </div>
-              </div>
+              <QuickActions actions={actions} />
 
               {/* Assigned Shows */}
               <div className='mt-8 bg-white rounded-lg shadow-sm p-6'>
@@ -284,77 +152,24 @@ export default function DirectorDashboard() {
                   Obras Asignadas
                 </h3>
                 <div className='space-y-4'>
-                  <div className='flex items-center justify-between p-4 bg-blue-50 rounded-lg border border-blue-200'>
-                    <div className='flex items-center'>
-                      <div className='w-12 h-12 bg-blue-100 rounded-lg flex items-center justify-center mr-4'>
-                        <FilmIcon className='h-6 w-6 text-blue-600' />
-                      </div>
-                      <div>
-                        <h4 className='font-medium text-gray-900'>
-                          Romeo y Julieta 2.0
-                        </h4>
-                        <p className='text-sm text-gray-600'>
-                          Drama interactivo • 8 preguntas
-                        </p>
-                      </div>
-                    </div>
-                    <div className='flex items-center space-x-2'>
-                      <span className='px-2 py-1 bg-green-100 text-green-800 text-xs rounded-full'>
-                        Activa
-                      </span>
-                      <button className='text-blue-600 hover:text-blue-800 text-sm font-medium'>
-                        Gestionar
-                      </button>
-                    </div>
-                  </div>
-
-                  <div className='flex items-center justify-between p-4 bg-gray-50 rounded-lg border border-gray-200'>
-                    <div className='flex items-center'>
-                      <div className='w-12 h-12 bg-gray-100 rounded-lg flex items-center justify-center mr-4'>
-                        <FilmIcon className='h-6 w-6 text-gray-600' />
-                      </div>
-                      <div>
-                        <h4 className='font-medium text-gray-900'>
-                          El Misterio del Teatro
-                        </h4>
-                        <p className='text-sm text-gray-600'>
-                          Misterio • 12 preguntas
-                        </p>
-                      </div>
-                    </div>
-                    <div className='flex items-center space-x-2'>
-                      <span className='px-2 py-1 bg-yellow-100 text-yellow-800 text-xs rounded-full'>
-                        En preparación
-                      </span>
-                      <button className='text-blue-600 hover:text-blue-800 text-sm font-medium'>
-                        Gestionar
-                      </button>
-                    </div>
-                  </div>
-
-                  <div className='flex items-center justify-between p-4 bg-gray-50 rounded-lg border border-gray-200'>
-                    <div className='flex items-center'>
-                      <div className='w-12 h-12 bg-gray-100 rounded-lg flex items-center justify-center mr-4'>
-                        <FilmIcon className='h-6 w-6 text-gray-600' />
-                      </div>
-                      <div>
-                        <h4 className='font-medium text-gray-900'>
-                          La Casa Encantada
-                        </h4>
-                        <p className='text-sm text-gray-600'>
-                          Terror • 6 preguntas
-                        </p>
-                      </div>
-                    </div>
-                    <div className='flex items-center space-x-2'>
-                      <span className='px-2 py-1 bg-gray-100 text-gray-800 text-xs rounded-full'>
-                        Finalizada
-                      </span>
-                      <button className='text-blue-600 hover:text-blue-800 text-sm font-medium'>
-                        Ver Reporte
-                      </button>
-                    </div>
-                  </div>
+                  <ShowCard
+                    title='Romeo y Julieta 2.0'
+                    subtitle='Drama interactivo • 8 preguntas'
+                    status='active'
+                    actionLabel='Gestionar'
+                  />
+                  <ShowCard
+                    title='El Misterio del Teatro'
+                    subtitle='Misterio • 12 preguntas'
+                    status='preparation'
+                    actionLabel='Gestionar'
+                  />
+                  <ShowCard
+                    title='La Casa Encantada'
+                    subtitle='Terror • 6 preguntas'
+                    status='finished'
+                    actionLabel='Ver Reporte'
+                  />
                 </div>
               </div>
             </>

--- a/src/components/QuickActions.tsx
+++ b/src/components/QuickActions.tsx
@@ -1,43 +1,95 @@
+import React from 'react';
 import { CalendarIcon, PlusIcon, UsersIcon } from '@heroicons/react/24/outline';
 
-export const QuickActions = () => {
+export type QuickActionColor = 'red' | 'orange' | 'blue' | 'green' | 'purple';
+
+export interface QuickAction {
+  icon: React.ReactElement;
+  title: string;
+  description: string;
+  color: QuickActionColor;
+}
+
+const colorStyles: Record<QuickActionColor, { border: string; hover: string; text: string; icon: string }> = {
+  red: {
+    border: 'border-red-200',
+    hover: 'hover:bg-red-50',
+    text: 'text-red-800',
+    icon: 'text-red-600',
+  },
+  orange: {
+    border: 'border-orange-200',
+    hover: 'hover:bg-orange-50',
+    text: 'text-orange-800',
+    icon: 'text-orange-600',
+  },
+  blue: {
+    border: 'border-blue-200',
+    hover: 'hover:bg-blue-50',
+    text: 'text-blue-800',
+    icon: 'text-blue-600',
+  },
+  green: {
+    border: 'border-green-200',
+    hover: 'hover:bg-green-50',
+    text: 'text-green-800',
+    icon: 'text-green-600',
+  },
+  purple: {
+    border: 'border-purple-200',
+    hover: 'hover:bg-purple-50',
+    text: 'text-purple-800',
+    icon: 'text-purple-600',
+  },
+};
+
+export interface QuickActionsProps {
+  actions?: QuickAction[];
+}
+
+const defaultActions: QuickAction[] = [
+  {
+    icon: <PlusIcon className='h-5 w-5' />,
+    title: 'Nueva Obra',
+    description: 'Crear una nueva obra teatral interactiva',
+    color: 'red',
+  },
+  {
+    icon: <CalendarIcon className='h-5 w-5' />,
+    title: 'Programar Función',
+    description: 'Crear nuevas fechas y horarios',
+    color: 'orange',
+  },
+  {
+    icon: <UsersIcon className='h-5 w-5' />,
+    title: 'Asignar Director',
+    description: 'Gestionar equipo de directores',
+    color: 'blue',
+  },
+];
+
+export const QuickActions: React.FC<QuickActionsProps> = ({ actions = defaultActions }) => {
   return (
     <div className='mt-8 bg-white rounded-lg shadow-sm p-6'>
-      <h3 className='text-lg font-semibold text-gray-900 mb-4'>
-        Acciones Rápidas
-      </h3>
+      <h3 className='text-lg font-semibold text-gray-900 mb-4'>Acciones Rápidas</h3>
       <div className='grid grid-cols-1 md:grid-cols-3 gap-4'>
-        <button className='p-4 border-2 border-red-200 rounded-lg hover:bg-red-50 transition-colors text-left group'>
-          <div className='flex items-center mb-2'>
-            <PlusIcon className='h-5 w-5 text-red-600 mr-2 group-hover:scale-110 transition-transform' />
-            <span className='font-medium text-red-800'>Nueva Obra</span>
-          </div>
-          <p className='text-sm text-gray-600'>
-            Crear una nueva obra teatral interactiva
-          </p>
-        </button>
-
-        <button className='p-4 border-2 border-orange-200 rounded-lg hover:bg-orange-50 transition-colors text-left group'>
-          <div className='flex items-center mb-2'>
-            <CalendarIcon className='h-5 w-5 text-orange-600 mr-2 group-hover:scale-110 transition-transform' />
-            <span className='font-medium text-orange-800'>
-              Programar Función
-            </span>
-          </div>
-          <p className='text-sm text-gray-600'>
-            Crear nuevas fechas y horarios
-          </p>
-        </button>
-
-        <button className='p-4 border-2 border-blue-200 rounded-lg hover:bg-blue-50 transition-colors text-left group'>
-          <div className='flex items-center mb-2'>
-            <UsersIcon className='h-5 w-5 text-blue-600 mr-2 group-hover:scale-110 transition-transform' />
-            <span className='font-medium text-blue-800'>Asignar Director</span>
-          </div>
-          <p className='text-sm text-gray-600'>
-            Gestionar equipo de directores
-          </p>
-        </button>
+        {actions.map((action, index) => {
+          const styles = colorStyles[action.color];
+          return (
+            <button
+              key={index}
+              className={`p-4 border-2 ${styles.border} rounded-lg ${styles.hover} transition-colors text-left group`}
+            >
+              <div className='flex items-center mb-2'>
+                {React.cloneElement(action.icon, {
+                  className: `h-5 w-5 ${styles.icon} mr-2 group-hover:scale-110 transition-transform`,
+                })}
+                <span className={`font-medium ${styles.text}`}>{action.title}</span>
+              </div>
+              <p className='text-sm text-gray-600'>{action.description}</p>
+            </button>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/components/director/LiveSessionStatus.tsx
+++ b/src/components/director/LiveSessionStatus.tsx
@@ -1,0 +1,40 @@
+import { ClockIcon } from '@heroicons/react/24/outline';
+
+export interface LiveSessionStatusProps {
+  play: string;
+  showTime: string;
+  expectedViewers: number;
+  questionCount: number;
+}
+
+export const LiveSessionStatus = ({
+  play,
+  showTime,
+  expectedViewers,
+  questionCount,
+}: LiveSessionStatusProps) => {
+  return (
+    <div className='mt-8 bg-gradient-to-r from-blue-500 to-purple-600 rounded-lg p-6 text-white'>
+      <h3 className='text-lg font-semibold mb-4 flex items-center'>
+        <ClockIcon className='h-5 w-5 mr-2' /> Estado de Sesión en Vivo
+      </h3>
+      <div className='grid grid-cols-1 md:grid-cols-3 gap-4'>
+        <div className='bg-white bg-opacity-20 rounded-lg p-4'>
+          <p className='text-sm opacity-90'>Próxima Función</p>
+          <p className='font-semibold text-lg'>{play}</p>
+          <p className='text-sm opacity-75'>{showTime}</p>
+        </div>
+        <div className='bg-white bg-opacity-20 rounded-lg p-4'>
+          <p className='text-sm opacity-90'>Espectadores Esperados</p>
+          <p className='font-semibold text-2xl'>{expectedViewers}</p>
+        </div>
+        <div className='bg-white bg-opacity-20 rounded-lg p-4'>
+          <p className='text-sm opacity-90'>Preguntas Preparadas</p>
+          <p className='font-semibold text-2xl'>{questionCount}</p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default LiveSessionStatus;

--- a/src/components/director/ShowCard.tsx
+++ b/src/components/director/ShowCard.tsx
@@ -1,0 +1,50 @@
+import { FilmIcon } from '@heroicons/react/24/outline';
+import React from 'react';
+
+export type ShowStatus = 'active' | 'preparation' | 'finished';
+
+interface ShowCardProps {
+  title: string;
+  subtitle: string;
+  status: ShowStatus;
+  actionLabel: string;
+}
+
+const statusStyles: Record<ShowStatus, string> = {
+  active: 'bg-green-100 text-green-800',
+  preparation: 'bg-yellow-100 text-yellow-800',
+  finished: 'bg-gray-100 text-gray-800',
+};
+
+export const ShowCard: React.FC<ShowCardProps> = ({
+  title,
+  subtitle,
+  status,
+  actionLabel,
+}) => (
+  <div className='flex items-center justify-between p-4 bg-gray-50 rounded-lg border border-gray-200'>
+    <div className='flex items-center'>
+      <div className='w-12 h-12 bg-gray-100 rounded-lg flex items-center justify-center mr-4'>
+        <FilmIcon className='h-6 w-6 text-gray-600' />
+      </div>
+      <div>
+        <h4 className='font-medium text-gray-900'>{title}</h4>
+        <p className='text-sm text-gray-600'>{subtitle}</p>
+      </div>
+    </div>
+    <div className='flex items-center space-x-2'>
+      <span className={`px-2 py-1 text-xs rounded-full ${statusStyles[status]}`}>{
+        status === 'active'
+          ? 'Activa'
+          : status === 'preparation'
+          ? 'En preparación'
+          : 'Finalizada'
+      }</span>
+      <button className='text-blue-600 hover:text-blue-800 text-sm font-medium'>
+        {actionLabel}
+      </button>
+    </div>
+  </div>
+);
+
+export default ShowCard;

--- a/src/components/ui/DashboardHeader.tsx
+++ b/src/components/ui/DashboardHeader.tsx
@@ -1,0 +1,52 @@
+import { ButtonLogout, ButtonStart } from './buttons';
+import { useAuth } from '@/contexts/AuthContext';
+
+export type DashboardHeaderProps = {
+  icon: string | React.ReactNode;
+  title: string;
+  color?: 'blue' | 'red' | 'purple';
+};
+
+const colorClasses = {
+  blue: {
+    border: 'border-blue-500',
+    title: 'text-blue-800',
+    subtitle: 'text-blue-600',
+  },
+  red: {
+    border: 'border-red-500',
+    title: 'text-red-800',
+    subtitle: 'text-red-600',
+  },
+  purple: {
+    border: 'border-purple-500',
+    title: 'text-purple-800',
+    subtitle: 'text-purple-600',
+  },
+} as const;
+
+export const DashboardHeader = ({ icon, title, color = 'blue' }: DashboardHeaderProps) => {
+  const { user } = useAuth();
+  const styles = colorClasses[color];
+  return (
+    <header className={`bg-white shadow-sm border-b-4 ${styles.border}`}>
+      <div className='max-w-7xl mx-auto px-4 sm:px-6 lg:px-8'>
+        <div className='flex justify-between items-center py-4'>
+          <div className='flex items-center'>
+            <div className='text-3xl mr-3'>{icon}</div>
+            <div>
+              <h1 className={`text-2xl font-bold ${styles.title}`}>{title}</h1>
+              <p className={styles.subtitle}>Bienvenido, {user?.name}</p>
+            </div>
+          </div>
+          <div className='flex items-center space-x-4'>
+            <ButtonStart />
+            <ButtonLogout />
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+};
+
+export default DashboardHeader;

--- a/src/components/ui/Spinner.tsx
+++ b/src/components/ui/Spinner.tsx
@@ -1,7 +1,23 @@
-export const Spinner = ({ message = 'Cargando...' }: { message?: string }) => {
+export const Spinner = ({
+  message = 'Cargando...',
+  color = 'red',
+}: {
+  message?: string;
+  color?: 'red' | 'blue' | 'purple';
+}) => {
+  const bgClasses: Record<'red' | 'blue' | 'purple', string> = {
+    red: 'bg-red-50',
+    blue: 'bg-blue-50',
+    purple: 'bg-purple-50',
+  };
+  const borderClasses: Record<'red' | 'blue' | 'purple', string> = {
+    red: 'border-red-600',
+    blue: 'border-blue-600',
+    purple: 'border-purple-600',
+  };
   return (
-    <div className='flex justify-center items-center min-h-screen bg-red-50'>
-      <div className='animate-spin rounded-full h-12 w-12 border-b-2 border-red-600' />
+    <div className={`flex justify-center items-center min-h-screen ${bgClasses[color]}`}>
+      <div className={`animate-spin rounded-full h-12 w-12 border-b-2 ${borderClasses[color]}`} />
       <span className='ml-3 text-gray-600'>{message}</span>
     </div>
   );


### PR DESCRIPTION
## Summary
- create `DashboardHeader` to share dashboard header UI
- extend `QuickActions` component with customizable actions
- add `LiveSessionStatus` and `ShowCard` for director views
- allow color selection in `Spinner`
- refactor director dashboard page to use new components

## Testing
- `pnpm lint` *(fails: next not found)*
- `pnpm test` *(fails: jest not found)*
- `pnpm typecheck` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68482636438c8322a2d96fa1903f0c9b